### PR TITLE
Test: Fix failing tests for recent scope

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,9 +1,8 @@
 class ArticlesController < ApplicationController
   def index
     articles = Article.recent
-    render json: Article.all
+    render json: articles
   end
-
 
   def show
     render json: Article.find(params[:id])
@@ -14,5 +13,4 @@ class ArticlesController < ApplicationController
   def serializer
     ArticleSerializer
   end
-
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -3,9 +3,5 @@ class Article < ApplicationRecord
   validates :content, presence: true
   validates :slug, presence: true, uniqueness: true
 
-
-
   scope :recent, -> { order(created_at: :desc) }
-
-
 end

--- a/spec/controllers/articles_controller.spec.rb
+++ b/spec/controllers/articles_controller.spec.rb
@@ -15,21 +15,20 @@ describe ArticlesController do
       subject
       expect(json_data.length).to eq(2)
       article_test = Article.recent
-      p article_test
       Article.recent.each_with_index do |article, index|
       expect(json_data[index]['attributes']).to eq({ "title" => article.title, "content" => article.content, "slug" => article.slug})
       end
     end
-    # TODO fix  this
+
     it 'should return articles in the proper order' do
       # use factory bot - using create helper
       old_article = create :article
       newer_article = create :article
       subject
       # want to check if the first object is the recent article
-      expect(json_data.first[:id]).to eq(newer_article.id.to_s)
+      expect(json_data.first['id']).to eq(newer_article.id.to_s)
       # check to see if its the old article
-      expect(json_data.last[:id]).to eq(old_article.id.to_s)
+      expect(json_data.last['id']).to eq(old_article.id.to_s)
 
     end
   end


### PR DESCRIPTION
Problem 1.
- used symbol when chekcing json keys. Returned json object has strings instead of symbols for identifying keys

Problem 2.
- in the controller there was an articles variable set up with recent scope, but below that variable was not used at all.